### PR TITLE
Automated recreating changed docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,14 @@
 all: copy-env
-	docker-compose up -d
+	docker-compose up -d --build
 
 copy-env:
 	if ! [ -e .env ]; then cp .env.tpl .env; fi;
-
-build:
-	docker-compose build
 
 clean:
 	docker-compose down
 
 local: copy-env
-	docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d
-
-build-local:
-	docker-compose -f docker-compose.yml -f docker-compose.local.yml build
+	docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
 
 clean-local:
 	docker-compose -f docker-compose.yml -f docker-compose.local.yml down


### PR DESCRIPTION
Currently CI automatically doesn't recreating changed docker images so changes don't apply. This PR fixes that by adding --build flag in Makefile.